### PR TITLE
Update image from buster to bookworm (Debian 12)

### DIFF
--- a/php7.3/Dockerfile
+++ b/php7.3/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bookworm
 
 # install the PHP extensions we need
 # see https://friendi.ca/resources/requirements/

--- a/php7.4/Dockerfile
+++ b/php7.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bookworm
 
 # install the PHP extensions we need
 # see https://friendi.ca/resources/requirements/

--- a/php8.0/Dockerfile
+++ b/php8.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bookworm
 
 # install the PHP extensions we need
 # see https://friendi.ca/resources/requirements/

--- a/php8.1/Dockerfile
+++ b/php8.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bookworm
 
 # install the PHP extensions we need
 # see https://friendi.ca/resources/requirements/

--- a/php8.2/Dockerfile
+++ b/php8.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bookworm
 
 # install the PHP extensions we need
 # see https://friendi.ca/resources/requirements/


### PR DESCRIPTION
The latest Debian release has been published a few weeks ago, so you might want to update the Docker images.